### PR TITLE
#166258838 in-app-browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "apollo-boost": "^0.4.4",
     "babel-plugin-inline-dotenv": "^1.3.3",
     "expo": "^34.0.1",
+    "expo-web-browser": "^6.0.0",
     "firebase": "^6.4.2",
     "graphql": "^14.5.3",
     "graphql-tag": "^2.10.1",

--- a/src/screens/profileScreen.js
+++ b/src/screens/profileScreen.js
@@ -7,9 +7,9 @@ import {
   Share,
   TouchableOpacity
 } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
 import Header from '../components/header';
 import Footer from '../components/footer';
-import userAvatar from '../../assets/userAvatar.png';
 class ProfileScreen extends Component {
   handleShare = async username => {
     const githubUrl = `https://github.com/${username}`;
@@ -22,9 +22,14 @@ class ProfileScreen extends Component {
       alert(error.message);
     }
   };
+
+  handleOpenBrowser = async url => {
+    await WebBrowser.openBrowserAsync(url);
+  };
   render() {
     const { navigation } = this.props;
     const item = navigation.getParam('item');
+    const url = `https://github.com/${item.node.login}`;
     return (
       <View>
         <Header navigation={navigation} />
@@ -35,9 +40,9 @@ class ProfileScreen extends Component {
           />
           <Text style={styles.usernameStyle}>{item.node.login}</Text>
           <Text style={styles.textOneStyle}>Github URL:</Text>
-          <Text
-            style={styles.textTwoStyle}
-          >{`https://github.com/${item.node.login}`}</Text>
+          <TouchableOpacity onPress={() => this.handleOpenBrowser(url)}>
+            <Text style={styles.textTwoStyle}>{url}</Text>
+          </TouchableOpacity>
           <View style={styles.viewOneStyle}>
             <Text style={styles.textThreeStyle}>
               {item.node.repositories.totalCount}


### PR DESCRIPTION
Description
=======
This feature is about implementing the functionality of viewing a developer's profile with an in-app-browser.

Type of change
=======
 - bring an in-app-browser containing a developer's Github profile when a user clicks on a GitHub URL of a developer. 


How has it been tested
=======
- pull this branch
- run ```npm install```
- run ```npm run ios``` to start our react app
-run  ```npm start``` and scan the QR-code to run the app on your device.

Checklist:
=======
N/A

Recording:
=======

![demo gif](http://g.recordit.co/BR8YHi2e92.gif)